### PR TITLE
Store operation into graph

### DIFF
--- a/include/tim/vx/graph.h
+++ b/include/tim/vx/graph.h
@@ -33,6 +33,8 @@ namespace vx {
 class Tensor;
 class TensorSpec;
 
+class Operation;
+
 class Graph {
  public:
   virtual ~Graph() {}
@@ -54,8 +56,13 @@ class Graph {
 
   template <typename OpType, typename... Params>
   std::shared_ptr<OpType> CreateOperation(Params... parameters) {
-    return std::make_shared<OpType>(this, parameters...);
+    auto op = std::make_shared<OpType>(this, parameters...);
+    opVector.push_back(op);
+    return op;
   }
+
+private:
+  std::vector<std::shared_ptr<tim::vx::Operation>> opVector;
 };
 
 }  // namespace vx


### PR DESCRIPTION
because the operation is a shared pointor, in app, the operation is
created as:
    auto op = graph->CreateOperation();

uses natively think the operation had been register into the graph and
would not manage the op locally.

if running the graph in another fucntion instead of the function that
create the operation, the operation would had been delete.

so the operation should be stored into the graph.

Signed-off-by: Jia <juku.jia@verisilicon.com>