### PR TITLE
Add map for InstanceNormalization

### DIFF
--- a/include/tim/vx/ops/instancenormalization.h
+++ b/include/tim/vx/ops/instancenormalization.h
@@ -1,0 +1,42 @@
+/****************************************************************************
+*
+*    Copyright (c) 2020 Vivante Corporation
+*
+*    Permission is hereby granted, free of charge, to any person obtaining a
+*    copy of this software and associated documentation files (the "Software"),
+*    to deal in the Software without restriction, including without limitation
+*    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+*    and/or sell copies of the Software, and to permit persons to whom the
+*    Software is furnished to do so, subject to the following conditions:
+*
+*    The above copyright notice and this permission notice shall be included in
+*    all copies or substantial portions of the Software.
+*
+*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+*    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+*    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+*    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+*    DEALINGS IN THE SOFTWARE.
+*
+*****************************************************************************/
+#ifndef TIM_VX_OPS_INSTANCENOMALIZATION_H_
+#define TIM_VX_OPS_INSTANCENOMALIZATION_H_
+#include "tim/vx/operation.h"
+
+namespace tim {
+namespace vx {
+namespace ops {
+class InstanceNormalization : public Operation {
+ public:
+  InstanceNormalization(Graph* graph, float eps);
+
+ protected:
+  float eps_;
+};
+
+}  // namespace ops
+}  // namespace vx
+}  // namespace tim
+#endif

--- a/src/tim/vx/ops/instancenormalization.cc
+++ b/src/tim/vx/ops/instancenormalization.cc
@@ -1,0 +1,39 @@
+/****************************************************************************
+*
+*    Copyright (c) 2021 Vivante Corporation
+*
+*    Permission is hereby granted, free of charge, to any person obtaining a
+*    copy of this software and associated documentation files (the "Software"),
+*    to deal in the Software without restriction, including without limitation
+*    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+*    and/or sell copies of the Software, and to permit persons to whom the
+*    Software is furnished to do so, subject to the following conditions:
+*
+*    The above copyright notice and this permission notice shall be included in
+*    all copies or substantial portions of the Software.
+*
+*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+*    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+*    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+*    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+*    DEALINGS IN THE SOFTWARE.
+*
+*****************************************************************************/
+#include "tim/vx/ops/instancenormalization.h"
+
+#include "operation_private.h"
+#include "vsi_nn_pub.h"
+
+namespace tim {
+namespace vx {
+namespace ops {
+InstanceNormalization::InstanceNormalization(Graph* graph, float eps)
+    : Operation(graph, VSI_NN_OP_INSTANCE_NORM), eps_(eps) {
+  this->impl()->node()->nn_param.instancenorm.eps = eps_;
+}
+
+}  // namespace ops
+}  // namespace vx
+}  // namespace tim

--- a/src/tim/vx/ops/instancenormalization_test.cc
+++ b/src/tim/vx/ops/instancenormalization_test.cc
@@ -1,0 +1,156 @@
+/****************************************************************************
+*
+*    Copyright (c) 2021 Vivante Corporation
+*
+*    Permission is hereby granted, free of charge, to any person obtaining a
+*    copy of this software and associated documentation files (the "Software"),
+*    to deal in the Software without restriction, including without limitation
+*    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+*    and/or sell copies of the Software, and to permit persons to whom the
+*    Software is furnished to do so, subject to the following conditions:
+*
+*    The above copyright notice and this permission notice shall be included in
+*    all copies or substantial portions of the Software.
+*
+*    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+*    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+*    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+*    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+*    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+*    DEALINGS IN THE SOFTWARE.
+*
+*****************************************************************************/
+#include "tim/vx/context.h"
+#include "tim/vx/graph.h"
+#include "tim/vx/ops/instancenormalization.h"
+
+#include "gtest/gtest.h"
+
+namespace {
+template<typename T>
+::testing::AssertionResult ArraysMatch(const std::vector<T>& expected,
+                                       const std::vector<T>& actual,
+                                       T abs_error){
+    for (size_t i = 0; i < expected.size(); ++i){
+        EXPECT_NEAR(expected[i], actual[i], abs_error) << "at index:" << i;
+    }
+
+    return ::testing::AssertionSuccess();
+}
+}
+
+TEST(OP, instance_norm_shape_3_6_1_float) {
+    auto ctx = tim::vx::Context::Create();
+    auto graph = ctx->CreateGraph();
+
+    tim::vx::ShapeType io_shape({3, 6, 1});
+    tim::vx::ShapeType param_shape({6});
+    tim::vx::TensorSpec input_spec(tim::vx::DataType::FLOAT32,
+                            io_shape, tim::vx::TensorAttribute::INPUT);
+    tim::vx::TensorSpec param_spec(tim::vx::DataType::FLOAT32,
+                            param_shape, tim::vx::TensorAttribute::INPUT);
+    tim::vx::TensorSpec output_spec(tim::vx::DataType::FLOAT32,
+                            io_shape, tim::vx::TensorAttribute::OUTPUT);
+
+    auto input_tensor = graph->CreateTensor(input_spec);
+    auto gamma_tensor = graph->CreateTensor(param_spec);
+    auto beta_tensor = graph->CreateTensor(param_spec);
+    auto output_tensor = graph->CreateTensor(output_spec);
+
+    std::vector<float> in_data = {
+        -2, 0, 2,
+        -3, 0, 3,
+        -4, 0, 4,
+        -5, 0, 5,
+        -6, 0, 6,
+        -7, 0, 7 };
+    std::vector<float> gamma = {
+        1.0f, 1.0f, 1.0f,
+        1.0f, 1.0f, 1.0f
+    };
+    std::vector<float> beta = {
+        .0f, .0f, .0f,
+        .0f, .0f, .0f
+    };
+    std::vector<float> golden = {
+        -1.22474f, 0, 1.22474f,
+        -1.22474f, 0, 1.22474f,
+        -1.22474f, 0, 1.22474f,
+        -1.22474f, 0, 1.22474f,
+        -1.22474f, 0, 1.22474f,
+        -1.22474f, 0, 1.22474f,
+    };
+
+    EXPECT_TRUE(input_tensor->CopyDataToTensor(in_data.data(), in_data.size()));
+    EXPECT_TRUE(gamma_tensor->CopyDataToTensor(gamma.data(), gamma.size() * sizeof(float)));
+    EXPECT_TRUE(beta_tensor->CopyDataToTensor(beta.data(), beta.size() * sizeof(float)));
+
+    auto op = graph->CreateOperation<tim::vx::ops::InstanceNormalization>(2e-5f);
+    (*op).BindInputs({input_tensor, beta_tensor, gamma_tensor}).BindOutputs({output_tensor});
+
+    EXPECT_TRUE(graph->Compile());
+    EXPECT_TRUE(graph->Run());
+
+    std::vector<float> output(18);
+    EXPECT_TRUE(output_tensor->CopyDataFromTensor(output.data()));
+    EXPECT_TRUE(ArraysMatch(golden, output, 1e-5f));
+}
+
+TEST(OP, instance_norm_shape_3_3_6_1_float) {
+    auto ctx = tim::vx::Context::Create();
+    auto graph = ctx->CreateGraph();
+
+    tim::vx::ShapeType io_shape({2, 3, 6, 1});
+    tim::vx::ShapeType param_shape({6});
+    tim::vx::TensorSpec input_spec(tim::vx::DataType::FLOAT32,
+                            io_shape, tim::vx::TensorAttribute::INPUT);
+    tim::vx::TensorSpec param_spec(tim::vx::DataType::FLOAT32,
+                            param_shape, tim::vx::TensorAttribute::INPUT);
+    tim::vx::TensorSpec output_spec(tim::vx::DataType::FLOAT32,
+                            io_shape, tim::vx::TensorAttribute::OUTPUT);
+
+    auto input_tensor = graph->CreateTensor(input_spec);
+    auto gamma_tensor = graph->CreateTensor(param_spec);
+    auto beta_tensor = graph->CreateTensor(param_spec);
+    auto output_tensor = graph->CreateTensor(output_spec);
+
+    std::vector<float> in_data = {
+        -2, 0, 2, -2, 0, 2,
+        -3, 0, 3, -3, 0, 3,
+        -4, 0, 4, -4, 0, 4,
+        -5, 0, 5, -5, 0, 5,
+        -6, 0, 6, -6, 0, 6,
+        -7, 0, 7, -7, 0, 7,
+        };
+    std::vector<float> gamma = {
+        1.0f, 1.0f, 1.0f,
+        1.0f, 1.0f, 1.0f
+    };
+    std::vector<float> beta = {
+        .0f, .0f, .0f,
+        .0f, .0f, .0f
+    };
+    std::vector<float> golden = {
+        -1.22474f, 0, 1.22474f, -1.22474f, 0, 1.22474f,
+        -1.22474f, 0, 1.22474f, -1.22474f, 0, 1.22474f,
+        -1.22474f, 0, 1.22474f, -1.22474f, 0, 1.22474f,
+        -1.22474f, 0, 1.22474f, -1.22474f, 0, 1.22474f,
+        -1.22474f, 0, 1.22474f, -1.22474f, 0, 1.22474f,
+        -1.22474f, 0, 1.22474f, -1.22474f, 0, 1.22474f,
+    };
+
+    EXPECT_TRUE(input_tensor->CopyDataToTensor(in_data.data(), in_data.size()));
+    EXPECT_TRUE(gamma_tensor->CopyDataToTensor(gamma.data(), gamma.size() * sizeof(float)));
+    EXPECT_TRUE(beta_tensor->CopyDataToTensor(beta.data(), beta.size() * sizeof(float)));
+
+    auto op = graph->CreateOperation<tim::vx::ops::InstanceNormalization>(2e-5f);
+    (*op).BindInputs({input_tensor, beta_tensor, gamma_tensor}).BindOutputs({output_tensor});
+
+    EXPECT_TRUE(graph->Compile());
+    EXPECT_TRUE(graph->Run());
+
+    std::vector<float> output(36);
+    EXPECT_TRUE(output_tensor->CopyDataFromTensor(output.data()));
+    EXPECT_TRUE(ArraysMatch(golden, output, 1e-5f));
+}


### PR DESCRIPTION
Currently instance normalization only support float32 data type.

Signed-off-by: zhao.xia <zhao.xia@verisilicon.com>