### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.14)
 project(tim-vx LANGUAGES C CXX)
 
-option(BUILD_SHARED_LIBS                "Build using shared libraries"          OFF)
+option(BUILD_SHARED_LIBS                "Build using shared libraries"          ON)
 option(TIM_VX_ENABLE_TEST               "Build the unit test"                   OFF)
 option(TIM_VX_ENABLE_LAYOUT_INFER       "Enable layout inference support"       ON)
 option(TIM_VX_ENABLE_NBG_PARSER         "Enable NBG parser"                     OFF)

--- a/src/tim/CMakeLists.txt
+++ b/src/tim/CMakeLists.txt
@@ -74,7 +74,7 @@ if(TIM_VX_ENABLE_TEST)
     include(GoogleTest)
 
     add_executable(unit_test ${${TARGET_NAME}_TEST_SRCS})
-    target_link_libraries(unit_test PRIVATE gtest gtest_main gmock gmock_main ${TARGET_NAME})
+    target_link_libraries(unit_test PRIVATE gtest gtest_main gmock gmock_main ${TARGET_NAME} ${OVXDRV_LIBRARIES})
     target_include_directories(unit_test PRIVATE
         ${PROJECT_SOURCE_DIR}/include
         ${CMAKE_CURRENT_SOURCE_DIR}/vx


### PR DESCRIPTION
Enable build tim-vx as dynamic-library by default will be more friendly for other repo such as tflite-vx-delegate.