### PR TITLE
close fast mode of graph

### DIFF
--- a/src/tim/vx/graph.cc
+++ b/src/tim/vx/graph.cc
@@ -156,6 +156,8 @@ bool GraphImpl::Compile() {
 
   vsi_nn_SetGraphVersion(graph_, major, minor, patch);
 
+  vsi_nn_SetGraphFastMode(graph_, false);
+
   std::call_once(setio_once_, [&status, this]() {
     status = (vsi_nn_SetGraphInputs(this->graph_, this->inputs_.data(),
                                     this->inputs_.size()) &&


### PR DESCRIPTION
keep the computation of graph high precision so that fp32 data would not be converted to fp16/bf16 

Signed-off-by: Jia <juku.jia@verisilicon.com>