### PR TITLE
fix 3 NPE checks in vsi_nn_ReleaseXxx

### DIFF
--- a/src/tim/vx/internal/src/vsi_nn_graph.c
+++ b/src/tim/vx/internal/src/vsi_nn_graph.c
@@ -614,8 +614,8 @@ void vsi_nn_ReleaseGraph
     uint32_t i;
     vsi_nn_graph_t  * ptr;
 
-    ptr = *graph;
-    if( NULL != graph && NULL != * graph )
+    ptr = NULL != graph ? *graph : NULL;
+    if( NULL != ptr )
     {
         if( NULL != ptr->nodes )
         {

--- a/src/tim/vx/internal/src/vsi_nn_node.c
+++ b/src/tim/vx/internal/src/vsi_nn_node.c
@@ -106,8 +106,8 @@ void vsi_nn_ReleaseNode
     )
 {
     vsi_nn_node_t * ptr;
-    ptr = *node;
-    if( NULL != node && NULL != *node )
+    ptr = NULL != node ? *node : NULL;
+    if( NULL != ptr )
     {
         vsi_nn_OpDeinit( ptr->op, ptr );
         if( NULL != ptr->input.tensors )

--- a/src/tim/vx/internal/src/vsi_nn_tensor.c
+++ b/src/tim/vx/internal/src/vsi_nn_tensor.c
@@ -785,8 +785,8 @@ void vsi_nn_ReleaseTensor
     )
 {
     vsi_nn_tensor_t * ptr;
-    ptr = *tensor;
-    if( NULL != tensor && NULL != *tensor )
+    ptr = NULL != tensor ? *tensor : NULL;
+    if( NULL != ptr )
     {
         uint8_t * handle = NULL;
         if( NULL != ptr->t )


### PR DESCRIPTION
3 APIs including `vsi_nn_ReleaseGraph` mistakenly read pointer arguments before checking NULL, so this PR fixes it.