### PR TITLE
fix some comments of Mish and LRN layer

### DIFF
--- a/include/tim/vx/ops/activations.h
+++ b/include/tim/vx/ops/activations.h
@@ -51,11 +51,11 @@ namespace ops {
  *
  *   HardSwish(x)           : 0 if x <= -3; x(x + 3)/6 if -3 < x < 3; x if x >= 3
  *
- *   Mish(x)                : x if x >= 0 else alpha * x
- *
  *   HardSigmoid(x)         : min(max(alpha*x + beta, 0), 1)
  *
  *   SoftRelu(x)            : log(1 + e^x). Also known as SoftPlus.
+ *
+ *   Mish(x)                : x * tanh(softrelu(x))
  *
  *   LeakyRelu(x)           : alpha * x if x <= 0; x if x > 0. alpha is a scalar.
  *

--- a/include/tim/vx/ops/localresponsenormalization.h
+++ b/include/tim/vx/ops/localresponsenormalization.h
@@ -33,7 +33,7 @@
  * ```
  * sqr_sum[a, b, c, d] = sum(
  *     pow(input[a, b, c, d - depth_radius : d + depth_radius + 1], 2))
- *     output = input / pow((bias + alpha * sqr_sum), beta)
+ * output = input / pow((bias + alpha * sqr_sum), beta)
  * ```
  */
 


### PR DESCRIPTION
The formula of Mish was wrong, while I've verified `VSI_NN_OP_MISH` does execute just standard `Mish` computation, so this PR fixes it.