### PR TITLE
CI enhancement - enable benchmark_model and samples

### DIFF
--- a/.github/workflows/0001-TensorFlow-V280-Enable-External-Delegate.patch
+++ b/.github/workflows/0001-TensorFlow-V280-Enable-External-Delegate.patch
@@ -1,0 +1,103 @@
+From b1df3172a116cf9e4bea878d7f568b1ceb4633b1 Mon Sep 17 00:00:00 2001
+From: "xiang.zhang" <xiang.zhang@verisilicon.com>
+Date: Wed, 23 Feb 2022 17:10:51 +0800
+Subject: [PATCH 1/1] TensorFlow V280 Enable External Delegate
+
+Signed-off-by: xiang.zhang <xiang.zhang@verisilicon.com>
+---
+ tensorflow/lite/CMakeLists.txt                  | 17 +++++++++++++++++
+ .../lite/examples/label_image/CMakeLists.txt    |  5 +++++
+ tensorflow/lite/tools/benchmark/CMakeLists.txt  |  5 +++++
+ 3 files changed, 27 insertions(+)
+
+diff --git a/tensorflow/lite/CMakeLists.txt b/tensorflow/lite/CMakeLists.txt
+index 200d1a7c46d..ec2dcf37d8e 100644
+--- a/tensorflow/lite/CMakeLists.txt
++++ b/tensorflow/lite/CMakeLists.txt
+@@ -68,6 +68,7 @@ option(TFLITE_ENABLE_MMAP "Enable MMAP (unsupported on Windows)" ON)
+ option(TFLITE_ENABLE_GPU "Enable GPU" OFF)
+ option(TFLITE_ENABLE_METAL "Enable Metal delegate (iOS only)" OFF)
+ option(TFLITE_ENABLE_XNNPACK "Enable XNNPACK backend" ON)
++option(TFLITE_ENABLE_EXTERNAL_DELEGATE "Enable external delegate" ON)
+ 
+ option(TFLITE_KERNEL_TEST "Enable tflite kernel unit test" OFF)
+ if(TFLITE_KERNEL_TEST AND ${CMAKE_CROSSCOMPILING})
+@@ -386,6 +387,16 @@ else()
+     "${TFLITE_SOURCE_DIR}/nnapi/nnapi_implementation_disabled.cc"
+   )
+ endif()
++if(TFLITE_ENABLE_EXTERNAL_DELEGATE)
++   populate_tflite_source_vars("delegates/external"
++    TFLITE_DELEGATES_EXTERNAL_SRCS
++    FILTER "(_test_list|_disabled)\\.(cc|h)$"
++   )
++   list(APPEND TFLITE_DELEGATES_EXTERNAL_SRCS
++     ${TFLITE_SOURCE_DIR}/tools/command_line_flags.cc
++   )
++   set(TFLITE_DELEGATES_EXTERNAL_INCL "delegates/external")
++endif()
+ if(TFLITE_ENABLE_XNNPACK)
+   find_package(fp16_headers REQUIRED)
+   find_package(xnnpack REQUIRED)
+@@ -451,6 +462,7 @@ endif()
+ set(TFLITE_INCLUDE_DIRS
+   "${TENSORFLOW_SOURCE_DIR}"
+   "${TFLITE_FLATBUFFERS_SCHEMA_DIR}"
++  "${TFLITE_DELEGATES_EXTERNAL_INCL}"
+ )
+ include_directories(
+   BEFORE
+@@ -462,6 +474,7 @@ add_library(tensorflow-lite
+   ${TFLITE_CORE_API_SRCS}
+   ${TFLITE_CORE_SRCS}
+   ${TFLITE_C_SRCS}
++  ${TFLITE_DELEGATES_EXTERNAL_SRCS}
+   ${TFLITE_DELEGATES_FLEX_SRCS}
+   ${TFLITE_DELEGATES_GPU_SRCS}
+   ${TFLITE_DELEGATES_NNAPI_SRCS}
+@@ -507,6 +520,10 @@ target_link_libraries(tensorflow-lite
+     ${TFLITE_TARGET_DEPENDENCIES}
+ )
+ 
++if (ANDROID_TOOLCHAIN)
++    list(APPEND tensorflow-lite log)
++endif()
++
+ if (NOT BUILD_SHARED_LIBS)
+   list(APPEND TFLITE_TARGET_PUBLIC_OPTIONS "-DTFL_STATIC_LIBRARY_BUILD")
+ endif()
+diff --git a/tensorflow/lite/examples/label_image/CMakeLists.txt b/tensorflow/lite/examples/label_image/CMakeLists.txt
+index 1bf259aad10..ed64afd39b2 100644
+--- a/tensorflow/lite/examples/label_image/CMakeLists.txt
++++ b/tensorflow/lite/examples/label_image/CMakeLists.txt
+@@ -55,6 +55,11 @@ if(TFLITE_ENABLE_GPU)
+   )
+ endif()  # TFLITE_ENABLE_GPU
+ 
++if(TFLITE_ENABLE_EXTERNAL_DELEGATE)
++  list(APPEND TFLITE_LABEL_IMAGE_SRCS
++          ${TFLITE_SOURCE_DIR}/tools/delegates/external_delegate_provider.cc)
++endif()
++
+ add_executable(label_image
+   EXCLUDE_FROM_ALL
+   ${TFLITE_LABEL_IMAGE_SRCS}
+diff --git a/tensorflow/lite/tools/benchmark/CMakeLists.txt b/tensorflow/lite/tools/benchmark/CMakeLists.txt
+index d66af0dcd4a..2b9a57a168b 100644
+--- a/tensorflow/lite/tools/benchmark/CMakeLists.txt
++++ b/tensorflow/lite/tools/benchmark/CMakeLists.txt
+@@ -72,6 +72,11 @@ if(TFLITE_ENABLE_GPU)
+   )
+ endif()  # TFLITE_ENABLE_GPU
+ 
++if(TFLITE_ENABLE_EXTERNAL_DELEGATE)
++  list(APPEND TFLITE_BENCHMARK_SRCS
++	  ${TFLITE_SOURCE_DIR}/tools/delegates/external_delegate_provider.cc)
++endif()
++
+ add_executable(benchmark_model
+   EXCLUDE_FROM_ALL
+   ${TFLITE_BENCHMARK_SRCS}
+-- 
+2.26.2
+

--- a/.github/workflows/cmake_x86_vsim_unit_test.yml
+++ b/.github/workflows/cmake_x86_vsim_unit_test.yml
@@ -1,4 +1,4 @@
-name: cmake_x86_vsim_unit_test
+name: cmake_x86_vsim
 
 on:
   # push:
@@ -11,9 +11,12 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
+  LD_LIBRARY_PATH: ${{github.workspace}}/tim-vx-install/prebuilt-sdk/x86_64_linux/lib:${{github.workspace}}/tim-vx-install/build/lib:${{github.workspace}}/tim-vx-install/tim-vx.install.dir/lib
+  VIVANTE_SDK_DIR: ${{github.workspace}}/tim-vx-install/prebuilt-sdk/x86_64_linux/
+  VSI_NN_LOG_LEVEL: 5
 
 jobs:
-  build:
+  tim-vx-build:
     # The CMake configure and build commands are platform agnostic and should work equally
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
@@ -26,15 +29,310 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DTIM_VX_ENABLE_TEST=ON
+      run: |
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DTIM_VX_ENABLE_TEST=ON -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/tim-vx.install.dir/ -DTIM_VX_BUILD_EXAMPLES=ON -DTIM_VX_ENABLE_PLATFORM=ON -DTIM_VX_ENABLE_CUSTOM_OP=ON
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+    - name: tvx-install
+      run: |
+        cmake --install ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+    - name: upload tim-vx-install
+      uses: actions/upload-artifact@v3
+      with:
+        name: tim-vx-install
+        path: |
+          ${{github.workspace}}/prebuilt-sdk
+          ${{github.workspace}}/build/lib
+          ${{github.workspace}}/tim-vx.install.dir/
+          ${{github.workspace}}/.github/
+
+  tim-vx-build-clang:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+      CXX: clang++
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: |
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DTIM_VX_ENABLE_TEST=ON -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/tim-vx.install.dir/
 
     - name: Build
       # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
-    - name: execute-unit-test.x86.vsim
+  tim-vx-unit-test:
+    needs: tim-vx-build
+    runs-on: ubuntu-latest
+    env:
+      LD_LIBRARY_PATH: ${{github.workspace}}/prebuilt-sdk/x86_64_linux/lib:${{github.workspace}}/build/lib:${{github.workspace}}/tim-vx.install.dir/lib
+      VIVANTE_SDK_DIR: ${{github.workspace}}/prebuilt-sdk/x86_64_linux/
+    steps:
+    - name: download tim-vx build output
+      uses: actions/download-artifact@v3
+      with:
+        name: tim-vx-install
+
+    - name: tim-vx.unit-test.x86.vsim
       run: |
-        export LD_LIBRARY_PATH=`pwd`/prebuilt-sdk/x86_64_linux/lib
-        export VIVANTE_SDK_DIR=`pwd`/prebuilt-sdk/x86_64_linux/
-        cd ${{github.workspace}}/build/src/tim/
+        cd ${{github.workspace}}/tim-vx.install.dir/bin
+        chmod u+x ./unit_test
         ./unit_test
+    - name: tim-vx.samples
+      run: |
+        cd ${{github.workspace}}/tim-vx.install.dir/bin
+        chmod u+x multi_thread_test
+        chmod u+x lenet_multi_device
+        ./multi_thread_test
+        ./lenet_multi_device
+
+  vx-delegate-build:
+    runs-on: ubuntu-latest
+    needs: tim-vx-build
+    steps:
+      - name: download tim-vx build output
+        uses: actions/download-artifact@v3
+        with:
+          name: tim-vx-install
+      - name: apply-patch-build
+        run: |
+          git config --global user.email "xiang.zhang@verisilicon.com"
+          git config --global user.name "xiang.zhang"
+          git clone https://github.com/tensorflow/tensorflow.git ${{github.workspace}}/3rd-party/tensorflow && cd ${{github.workspace}}/3rd-party/tensorflow/ && git checkout v2.8.0 && git am ${{github.workspace}}/.github/workflows/0001-TensorFlow-V280-Enable-External-Delegate.patch
+          git clone https://github.com/VeriSilicon/tflite-vx-delegate.git ${{github.workspace}}/vx-delegate
+          cmake -B ${{github.workspace}}/vx-delegate/build -S ${{github.workspace}}/vx-delegate -DFETCHCONTENT_SOURCE_DIR_TENSORFLOW=${{github.workspace}}/3rd-party/tensorflow -DTIM_VX_INSTALL=${{github.workspace}}/tim-vx.install.dir/ -DTFLITE_ENABLE_NNAPI=OFF -DTFLITE_ENABLE_XNNPACK=OFF
+          cmake --build ${{github.workspace}}/vx-delegate/build --config ${{env.BUILD_TYPE}}
+          cd ${{github.workspace}}/vx-delegate/build
+          make vx_delegate benchmark_model
+      - name: upload vx-delegate
+        uses: actions/upload-artifact@v3
+        with:
+          name: vx-delegate-bin
+          path: |
+            ${{github.workspace}}/vx-delegate/build/_deps/tensorflow-build/tools/benchmark/benchmark_model
+            ${{github.workspace}}/vx-delegate/build/libvx_delegate.so
+
+  # AI-Benchmark 5.0.1 model zoo
+  mobilenet_v2_quant:
+    runs-on: ubuntu-latest
+    needs: vx-delegate-build
+    steps:
+      - name: download binary
+        uses: actions/download-artifact@v3
+
+      - name: download mobilenet_v2_quant.tflite
+        run: |
+          curl -LJO https://github.com/sunshinemyson/TIM-VX/releases/download/v1.1.30.2/mobilenet_v2_quant.tflite
+      - name: benchmark_model
+        run: |
+          chmod u+x ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model
+          ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model --num_runs=1 --external_delegate_path=${{github.workspace}}/vx-delegate-bin/libvx_delegate.so --graph=${{github.workspace}}/mobilenet_v2_quant.tflite
+
+  mobilenet_v2_b8_quant:
+    runs-on: ubuntu-latest
+    needs: vx-delegate-build
+    steps:
+      - name: download binary
+        uses: actions/download-artifact@v3
+      - name: download mobilenet_v2_b8_quant.tflite
+        run: |
+          curl -LJO https://github.com/sunshinemyson/TIM-VX/releases/download/v1.1.30.2/mobilenet_v2_b8_quant.tflite
+      - name: benchmark_model
+        run: |
+          chmod u+x ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model
+          ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model --num_runs=1 --external_delegate_path=${{github.workspace}}/vx-delegate-bin/libvx_delegate.so --graph=${{github.workspace}}/mobilenet_v2_b8_quant.tflite
+
+  resnet_quant:
+    runs-on: ubuntu-latest
+    needs: vx-delegate-build
+    steps:
+      - name: download test binary
+        uses: actions/download-artifact@v3
+      - name: download resnet_quant.tflite
+        run: |
+          curl -LJO https://github.com/sunshinemyson/TIM-VX/releases/download/v1.1.30.2/resnet_quant.tflite
+      - name: benchmark_model
+        run: |
+          chmod u+x ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model
+          ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model --num_runs=1 --external_delegate_path=${{github.workspace}}/vx-delegate-bin/libvx_delegate.so --graph=${{github.workspace}}/resnet_quant.tflite
+
+  inception_v3_quant:
+    runs-on: ubuntu-latest
+    needs: vx-delegate-build
+    steps:
+      - name: download test binary
+        uses: actions/download-artifact@v3
+      - name: download model
+        run: |
+          curl -LJO https://github.com/sunshinemyson/TIM-VX/releases/download/v1.1.30.2/inception_v3_quant.tflite
+      - name: benchmark_model
+        run: |
+          chmod u+x ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model
+          ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model --num_runs=1 --external_delegate_path=${{github.workspace}}/vx-delegate-bin/libvx_delegate.so --graph=${{github.workspace}}/inception_v3_quant.tflite
+
+  mobilenet_v3_b4_quant:
+    runs-on: ubuntu-latest
+    needs: vx-delegate-build
+    steps:
+      - name: download test binary
+        uses: actions/download-artifact@v3
+      - name: download model
+        run: |
+          curl -LJO https://github.com/sunshinemyson/TIM-VX/releases/download/v1.1.30.2/mobilenet_v3_b4_quant.tflite
+      - name: benchmark_model
+        run: |
+          chmod u+x ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model
+          ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model --num_runs=1 --external_delegate_path=${{github.workspace}}/vx-delegate-bin/libvx_delegate.so --graph=${{github.workspace}}/mobilenet_v3_b4_quant.tflite
+
+  mobilenet_v3_quant:
+    runs-on: ubuntu-latest
+    needs: vx-delegate-build
+    steps:
+      - name: download test binary
+        uses: actions/download-artifact@v3
+      - name: download model
+        run: |
+          curl -LJO https://github.com/sunshinemyson/TIM-VX/releases/download/v1.1.30.2/mobilenet_v3_quant.tflite
+      - name: benchmark_model
+        run: |
+          chmod u+x ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model
+          ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model --num_runs=1 --external_delegate_path=${{github.workspace}}/vx-delegate-bin/libvx_delegate.so --graph=${{github.workspace}}/mobilenet_v3_quant.tflite
+
+  mv3_depth_quant:
+    runs-on: ubuntu-latest
+    needs: vx-delegate-build
+    steps:
+      - name: download test binary
+        uses: actions/download-artifact@v3
+      - name: download model
+        run: |
+          curl -LJO https://github.com/sunshinemyson/TIM-VX/releases/download/v1.1.30.2/mv3_depth_quant.tflite
+      - name: benchmark_model
+        run: |
+          chmod u+x ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model
+          ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model --num_runs=1 --external_delegate_path=${{github.workspace}}/vx-delegate-bin/libvx_delegate.so --graph=${{github.workspace}}/mv3_depth_quant.tflite
+
+  yolo_v4_tiny_quant:
+    runs-on: ubuntu-latest
+    needs: vx-delegate-build
+    steps:
+      - name: download test binary
+        uses: actions/download-artifact@v3
+      - name: download model
+        run: |
+          curl -LJO https://github.com/sunshinemyson/TIM-VX/releases/download/v1.1.30.2/yolo_v4_tiny_quant.tflite
+      - name: benchmark_model
+        run: |
+          chmod u+x ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model
+          ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model --num_runs=1 --external_delegate_path=${{github.workspace}}/vx-delegate-bin/libvx_delegate.so --graph=${{github.workspace}}/yolo_v4_tiny_quant.tflite
+
+  # Disable huge compilation cost
+  # deeplab_v3_plus_quant:
+  #   runs-on: ubuntu-latest
+  #   needs: vx-delegate-build
+  #   steps:
+  #     - name: download test binary
+  #       uses: actions/download-artifact@v3
+  #     - name: download model
+  #       run: |
+  #         curl -LJO https://github.com/sunshinemyson/TIM-VX/releases/download/v1.1.30.2/deeplab_v3_plus_quant.tflite
+  #     - name: benchmark_model
+  #       run: |
+  #         chmod u+x ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model
+  #         ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model --num_runs=1 --external_delegate_path=${{github.workspace}}/vx-delegate-bin/libvx_delegate.so --graph=${{github.workspace}}/deeplab_v3_plus_quant.tflite
+
+  # Tensorflow Hub
+  # tfhub-movenet-multipose:
+  #   runs-on: ubuntu-latest
+  #   needs: vx-delegate-build
+  #   steps:
+  #     - name: download test binary
+  #       uses: actions/download-artifact@v3
+  #     - name: download model
+  #       run: |
+  #         wget https://storage.googleapis.com/tfhub-lite-models/google/lite-model/movenet/multipose/lightning/tflite/float16/1.tflite
+  #         mv 1.tflite tfhub.movenet.multipose.tflite
+  #     - name: benchmark-model
+  #       run: |
+  #         chmod u+x ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model
+  #         ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model --num_runs=1 --external_delegate_path=${{github.workspace}}/vx-delegate-bin/libvx_delegate.so --graph=${{github.workspace}}/tfhub.movenet.multipose.tflite
+
+  tfhub-efficientdet-lite0:
+    runs-on: ubuntu-latest
+    needs: vx-delegate-build
+    steps:
+      - name: download test binary
+        uses: actions/download-artifact@v3
+      - name: download model
+        run: |
+          wget https://storage.googleapis.com/tfhub-lite-models/tensorflow/lite-model/efficientdet/lite0/detection/metadata/1.tflite
+      - name: benchmark-model
+        run: |
+          chmod u+x ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model
+          ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model --num_runs=1 --external_delegate_path=${{github.workspace}}/vx-delegate-bin/libvx_delegate.so --graph=${{github.workspace}}/1.tflite
+
+  tfhub-efficientdet-lite1:
+    runs-on: ubuntu-latest
+    needs: vx-delegate-build
+    steps:
+      - name: download test binary
+        uses: actions/download-artifact@v3
+      - name: download model
+        run: |
+          wget https://storage.googleapis.com/tfhub-lite-models/tensorflow/lite-model/efficientdet/lite1/detection/metadata/1.tflite
+      - name: benchmark-model
+        run: |
+          chmod u+x ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model
+          ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model --num_runs=1 --external_delegate_path=${{github.workspace}}/vx-delegate-bin/libvx_delegate.so --graph=${{github.workspace}}/1.tflite
+
+  tfhub-efficientdet-lite2:
+    runs-on: ubuntu-latest
+    needs: vx-delegate-build
+    steps:
+      - name: download test binary
+        uses: actions/download-artifact@v3
+      - name: download model
+        run: |
+          wget https://storage.googleapis.com/tfhub-lite-models/tensorflow/lite-model/efficientdet/lite2/detection/metadata/1.tflite
+      - name: benchmark-model
+        run: |
+          chmod u+x ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model
+          ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model --num_runs=1 --external_delegate_path=${{github.workspace}}/vx-delegate-bin/libvx_delegate.so --graph=${{github.workspace}}/1.tflite
+
+  tfhub-efficientdet-lite3:
+    runs-on: ubuntu-latest
+    needs: vx-delegate-build
+    steps:
+      - name: download test binary
+        uses: actions/download-artifact@v3
+      - name: download model
+        run: |
+          wget https://storage.googleapis.com/tfhub-lite-models/tensorflow/lite-model/efficientdet/lite2/detection/metadata/1.tflite
+      - name: benchmark-model
+        run: |
+          chmod u+x ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model
+          ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model --num_runs=1 --external_delegate_path=${{github.workspace}}/vx-delegate-bin/libvx_delegate.so --graph=${{github.workspace}}/1.tflite
+
+  # Graph compilation time is huge over 20mins
+  # tfhub-efficientdet-lite4:
+  #   runs-on: ubuntu-latest
+  #   needs: vx-delegate-build
+  #   steps:
+  #     - name: download test binary
+  #       uses: actions/download-artifact@v3
+  #     - name: download model
+  #       run: |
+  #         wget https://storage.googleapis.com/tfhub-lite-models/tensorflow/lite-model/efficientdet/lite4/detection/metadata/1.tflite
+  #     - name: benchmark-model
+  #       run: |
+  #         chmod u+x ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model
+  #         ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model --num_runs=1 --external_delegate_path=${{github.workspace}}/vx-delegate-bin/libvx_delegate.so --graph=${{github.workspace}}/1.tflite

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(TIM_VX_BUILD_EXAMPLES            "Build demos show general usage"        
 option(TIM_VX_ENABLE_VIPLITE            "Enable lite driver api support"        OFF)
 option(TIM_VX_ENABLE_40BIT              "Enable large memory support"           OFF)
 option(TIM_VX_ENABLE_PLATFORM           "Enable multi devices support"          OFF)
+option(TIM_VX_ENABLE_CUSTOM_OP          "Enable customized op example"          OFF)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/samples/benchmark_test/benchmark_test.cc
+++ b/samples/benchmark_test/benchmark_test.cc
@@ -45,7 +45,7 @@ int main(int argc, char* argv[]) {
     uint32_t out_image_h = default_cfg[kOutImageH];
     uint32_t out_image_c = default_cfg[kOutChannel];
     uint32_t is_depthwise = default_cfg[deptwise_option];
-    uint32_t multiplier;
+    uint32_t multiplier = 1;
 
     if (argc != 0 && argc != kConfigFiledCnt + 1){
         std::cout << "argc = " << argc << std::endl;

--- a/samples/custom_op_test/CMakeLists.txt
+++ b/samples/custom_op_test/CMakeLists.txt
@@ -6,7 +6,10 @@ aux_source_directory(. ${TARGET_NAME}_SRCS)
 add_executable(${TARGET_NAME} ${${TARGET_NAME}_SRCS})
 
 target_link_libraries(${TARGET_NAME} PRIVATE tim-vx)
-target_include_directories(${TARGET_NAME} PRIVATE 
+target_include_directories(${TARGET_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${PROJECT_SOURCE_DIR}/include
 )
+
+install(TARGETS ${TARGET_NAME} ${TARGET_NAME}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})

--- a/samples/lenet_multi_device/CMakeLists.txt
+++ b/samples/lenet_multi_device/CMakeLists.txt
@@ -6,7 +6,10 @@ aux_source_directory(. ${TARGET_NAME}_SRCS)
 add_executable(${TARGET_NAME} ${${TARGET_NAME}_SRCS})
 
 target_link_libraries(${TARGET_NAME} PRIVATE -Wl,--whole-archive tim-vx)
-target_include_directories(${TARGET_NAME} PRIVATE 
+target_include_directories(${TARGET_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${PROJECT_SOURCE_DIR}/include
 )
+
+install(TARGETS ${TARGET_NAME} ${TARGET_NAME}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})

--- a/samples/multi_thread_test/CMakeLists.txt
+++ b/samples/multi_thread_test/CMakeLists.txt
@@ -8,7 +8,10 @@ aux_source_directory(. ${TARGET_NAME}_SRCS)
 add_executable(${TARGET_NAME} ${${TARGET_NAME}_SRCS})
 
 target_link_libraries(${TARGET_NAME} PRIVATE tim-vx Threads::Threads)
-target_include_directories(${TARGET_NAME} PRIVATE 
+target_include_directories(${TARGET_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${PROJECT_SOURCE_DIR}/include
 )
+
+install(TARGETS ${TARGET_NAME} ${TARGET_NAME}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Added Clang build check with CMAKE
Added vx-delegate build and benchmark_model test for PR.
Added tim-vx/samples in ci
Save output from build for debugging purpose.
Parallel CI execution.

Signed-off-by: xiang.zhang <xiang.zhang@verisilicon.com>