### PR TITLE
feat(tensor): support external buffer when creating input/output tensors

### DIFF
--- a/src/tim/vx/tensor.cc
+++ b/src/tim/vx/tensor.cc
@@ -198,11 +198,11 @@ bool TensorImpl::Init() {
         graph_->graph(),
         VSI_NN_TENSOR_ID_AUTO,  // DMABUF's fd is created by TensorFromHandle as input or output,
         &attr,
-        fd_ != -1 ? (uint8_t*)fd_ : nullptr);  // and cannot be set to const
+        fd_ != -1 ? (uint8_t*)fd_ : (uint8_t*)data_);  // and cannot be set to const
 #else
     if (-1 == fd_) {
       id_ = vsi_nn_AddTensorFromHandle(graph_->graph(), VSI_NN_TENSOR_ID_AUTO,
-                                       &attr, nullptr);
+                                       &attr, (uint8_t*)data_);
     } else {
       id_ = 0xFFFFFFFF;
       VSILOGE("Create tensor fail: low-level driver doesn't support dmabuffer");
@@ -220,7 +220,7 @@ bool TensorImpl::Init() {
     return false;
   }
 
-  if (data_) {
+  if (data_ && !(spec_.attr_ & (TensorAttribute::INPUT | TensorAttribute::OUTPUT))) {
     if (!CopyDataToTensor(data_, 0)) {
       VSILOGE("Copy data to tensor fail!");
       return false;


### PR DESCRIPTION
**Intent**: Up to now TIM-VX allocates necessary tensor buffer on host memory, and `vsi_nn_AddTensorFromHandle` does accept a non-null `data` argument, so this PR enables a new usage of reusing data buffers from outsides for input and output tensors.

This PR extends and replaces #297.