### PR TITLE
Fixed no-output if transpose is last op and can be optimized

### DIFF
--- a/.github/workflows/cmake_x86_vsim.yml
+++ b/.github/workflows/cmake_x86_vsim.yml
@@ -117,7 +117,7 @@ jobs:
   # AI-Benchmark 5.0.1 model zoo
   mobilenet_v2_quant:
     runs-on: ubuntu-latest
-    needs: vx-delegate-build
+    needs: [vx-delegate-build, tim-vx-unit-test]
     steps:
       - name: download binary
         uses: actions/download-artifact@v3
@@ -132,7 +132,7 @@ jobs:
 
   mobilenet_v2_b8_quant:
     runs-on: ubuntu-latest
-    needs: vx-delegate-build
+    needs: [vx-delegate-build, tim-vx-unit-test]
     steps:
       - name: download binary
         uses: actions/download-artifact@v3
@@ -146,7 +146,7 @@ jobs:
 
   resnet_quant:
     runs-on: ubuntu-latest
-    needs: vx-delegate-build
+    needs: [vx-delegate-build, tim-vx-unit-test]
     steps:
       - name: download test binary
         uses: actions/download-artifact@v3
@@ -160,7 +160,7 @@ jobs:
 
   inception_v3_quant:
     runs-on: ubuntu-latest
-    needs: vx-delegate-build
+    needs: [vx-delegate-build, tim-vx-unit-test]
     steps:
       - name: download test binary
         uses: actions/download-artifact@v3
@@ -174,7 +174,7 @@ jobs:
 
   mobilenet_v3_b4_quant:
     runs-on: ubuntu-latest
-    needs: vx-delegate-build
+    needs: [vx-delegate-build, tim-vx-unit-test]
     steps:
       - name: download test binary
         uses: actions/download-artifact@v3
@@ -188,7 +188,7 @@ jobs:
 
   mobilenet_v3_quant:
     runs-on: ubuntu-latest
-    needs: vx-delegate-build
+    needs: [vx-delegate-build, tim-vx-unit-test]
     steps:
       - name: download test binary
         uses: actions/download-artifact@v3
@@ -202,7 +202,7 @@ jobs:
 
   mv3_depth_quant:
     runs-on: ubuntu-latest
-    needs: vx-delegate-build
+    needs: [vx-delegate-build, tim-vx-unit-test]
     steps:
       - name: download test binary
         uses: actions/download-artifact@v3
@@ -216,7 +216,7 @@ jobs:
 
   yolo_v4_tiny_quant:
     runs-on: ubuntu-latest
-    needs: vx-delegate-build
+    needs: [vx-delegate-build, tim-vx-unit-test]
     steps:
       - name: download test binary
         uses: actions/download-artifact@v3
@@ -231,7 +231,7 @@ jobs:
   # Disable huge compilation cost
   # deeplab_v3_plus_quant:
   #   runs-on: ubuntu-latest
-  #   needs: vx-delegate-build
+  #   needs: [vx-delegate-build, tim-vx-unit-test]
   #   steps:
   #     - name: download test binary
   #       uses: actions/download-artifact@v3
@@ -261,7 +261,7 @@ jobs:
 
   tfhub-efficientdet-lite0:
     runs-on: ubuntu-latest
-    needs: vx-delegate-build
+    needs: [vx-delegate-build, tim-vx-unit-test]
     steps:
       - name: download test binary
         uses: actions/download-artifact@v3
@@ -275,7 +275,7 @@ jobs:
 
   tfhub-efficientdet-lite1:
     runs-on: ubuntu-latest
-    needs: vx-delegate-build
+    needs: [vx-delegate-build, tim-vx-unit-test]
     steps:
       - name: download test binary
         uses: actions/download-artifact@v3
@@ -289,7 +289,7 @@ jobs:
 
   tfhub-efficientdet-lite2:
     runs-on: ubuntu-latest
-    needs: vx-delegate-build
+    needs: [vx-delegate-build, tim-vx-unit-test]
     steps:
       - name: download test binary
         uses: actions/download-artifact@v3
@@ -303,7 +303,7 @@ jobs:
 
   tfhub-efficientdet-lite3:
     runs-on: ubuntu-latest
-    needs: vx-delegate-build
+    needs: [vx-delegate-build, tim-vx-unit-test]
     steps:
       - name: download test binary
         uses: actions/download-artifact@v3
@@ -314,6 +314,20 @@ jobs:
         run: |
           chmod u+x ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model
           ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model --num_runs=1 --external_delegate_path=${{github.workspace}}/vx-delegate-bin/libvx_delegate.so --graph=${{github.workspace}}/1.tflite
+
+  acuity-yolov3-608-quant:
+    runs-on: ubuntu-latest
+    needs: [vx-delegate-build, tim-vx-unit-test]
+    steps:
+      - name: download test binary
+        uses: actions/download-artifact@v3
+      - name: download model
+        run: |
+          curl -LJO https://github.com/sunshinemyson/TIM-VX/releases/download/v1.1.30.2/yolov3_608relu_quant.acuity.tflite
+      - name: benchmark-model
+        run: |
+          chmod u+x ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model
+          ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model --num_runs=1 --external_delegate_path=${{github.workspace}}/vx-delegate-bin/libvx_delegate.so --graph=${{github.workspace}}/yolov3_608relu_quant.acuity.tflite
 
   # Graph compilation time is huge over 20mins
   # tfhub-efficientdet-lite4:

--- a/.github/workflows/cmake_x86_vsim.yml
+++ b/.github/workflows/cmake_x86_vsim.yml
@@ -315,19 +315,19 @@ jobs:
           chmod u+x ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model
           ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model --num_runs=1 --external_delegate_path=${{github.workspace}}/vx-delegate-bin/libvx_delegate.so --graph=${{github.workspace}}/1.tflite
 
-  acuity-yolov3-608-quant:
-    runs-on: ubuntu-latest
-    needs: [vx-delegate-build, tim-vx-unit-test]
-    steps:
-      - name: download test binary
-        uses: actions/download-artifact@v3
-      - name: download model
-        run: |
-          curl -LJO https://github.com/sunshinemyson/TIM-VX/releases/download/v1.1.30.2/yolov3_608relu_quant.acuity.tflite
-      - name: benchmark-model
-        run: |
-          chmod u+x ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model
-          ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model --num_runs=1 --external_delegate_path=${{github.workspace}}/vx-delegate-bin/libvx_delegate.so --graph=${{github.workspace}}/yolov3_608relu_quant.acuity.tflite
+  # acuity-yolov3-608-quant:
+  #   runs-on: ubuntu-latest
+  #   needs: [vx-delegate-build, tim-vx-unit-test]
+  #   steps:
+  #     - name: download test binary
+  #       uses: actions/download-artifact@v3
+  #     - name: download model
+  #       run: |
+  #         curl -LJO https://github.com/sunshinemyson/TIM-VX/releases/download/v1.1.30.2/yolov3_608relu_quant.acuity.tflite
+  #     - name: benchmark-model
+  #       run: |
+  #         chmod u+x ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model
+  #         ${{github.workspace}}/vx-delegate-bin/_deps/tensorflow-build/tools/benchmark/benchmark_model --num_runs=1 --external_delegate_path=${{github.workspace}}/vx-delegate-bin/libvx_delegate.so --graph=${{github.workspace}}/yolov3_608relu_quant.acuity.tflite
 
   # Graph compilation time is huge over 20mins
   # tfhub-efficientdet-lite4:


### PR DESCRIPTION
If transpose can be erased by layout inference, replace it as a
reshape - input and output have same shape - expect low-level
optimization erase the reshape

Signed-off-by: xiang.zhang <xiang.zhang@verisilicon.com>