### PR TITLE
Feat: disable maxpoolwithargmax2 if no low-level support

### DIFF
--- a/include/tim/vx/ops/maxpoolgrad.h
+++ b/include/tim/vx/ops/maxpoolgrad.h
@@ -21,6 +21,8 @@
 *    DEALINGS IN THE SOFTWARE.
 *
 *****************************************************************************/
+#if VSI_FEAT_OP_MAXPOOLWITHARGMAX
+
 #ifndef TIM_VX_OPS_MAXPOOLGRAD_H_
 #define TIM_VX_OPS_MAXPOOLGRAD_H_
 
@@ -68,3 +70,4 @@ class MaxpoolGrad: public Operation {
 }  // namespace tim
 
 #endif /*TIM_VX_OPS_MAXPOOLGRAD_H_*/
+#endif

--- a/include/tim/vx/ops/maxpoolwithargmax2.h
+++ b/include/tim/vx/ops/maxpoolwithargmax2.h
@@ -21,6 +21,7 @@
 *    DEALINGS IN THE SOFTWARE.
 *
 *****************************************************************************/
+#if VSI_FEAT_OP_MAXPOOLWITHARGMAX
 #ifndef TIM_VX_OPS_MAXPOOLWITHARGMAX2_H_
 #define TIM_VX_OPS_MAXPOOLWITHARGMAX2_H_
 
@@ -66,3 +67,5 @@ class MaxpoolWithArgmax2 : public DirectMapOp {
 }  // namespace tim
 
 #endif /* TIM_VX_OPS_MAXPOOLWITHARGMAX2_H_ */
+
+#endif //(VSI_FEAT_OP_MAXPOOLWITHARGMAX)

--- a/src/tim/CMakeLists.txt
+++ b/src/tim/CMakeLists.txt
@@ -81,6 +81,19 @@ if(${TIM_VX_ENABLE_VIPLITE})
     )
 endif()
 
+# convert op list as compile flags so that we can implement compile compatable easier
+if(${TIM_VX_USE_EXTERNAL_OVXLIB})
+    file(STRINGS "${OVXLIB_INC}/interface/ops.def" ops_file_content)
+else()
+    file(STRINGS "./vx/internal/include/interface/ops.def" ops_file_content)
+endif()
+string(LENGTH "/*;   Add new ops to the end.;*_/" comment_len)
+string(SUBSTRING "${ops_file_content}" ${comment_len} -1 op_list_only)
+string(REGEX REPLACE "DEF_OP\\(" "-DVSI_FEAT_OP_" op_list_tmp ${op_list_only})
+string(REGEX REPLACE "\\)" " " op_as_flags ${op_list_tmp})
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${op_as_flags}")
+
 add_library(${TARGET_NAME} ${${TARGET_NAME}_SRCS})
 target_include_directories(${TARGET_NAME} PRIVATE ${INC_DIRS})
 target_link_libraries(${TARGET_NAME} PUBLIC

--- a/src/tim/vx/ops/maxpoolgrad.cc
+++ b/src/tim/vx/ops/maxpoolgrad.cc
@@ -21,6 +21,7 @@
 *    DEALINGS IN THE SOFTWARE.
 *
 *****************************************************************************/
+#if VSI_FEAT_OP_MAXPOOLWITHARGMAX
 #include "tim/vx/ops.h"
 #include "vsi_nn_pub.h"
 #include "op_impl.h"
@@ -160,3 +161,5 @@ std::shared_ptr<Operation> MaxpoolGrad::Clone(
 }  // namespace ops
 }  // namespace vx
 }  // namespace tim
+
+#endif //(VSI_FEAT_OP_MAXPOOLWITHARGMAX)

--- a/src/tim/vx/ops/maxpoolgrad_test.cc
+++ b/src/tim/vx/ops/maxpoolgrad_test.cc
@@ -21,6 +21,7 @@
 *    DEALINGS IN THE SOFTWARE.
 *
 *****************************************************************************/
+#if VSI_FEAT_OP_MAXPOOLWITHARGMAX
 #include "tim/vx/context.h"
 #include "tim/vx/graph.h"
 #include "tim/vx/ops/maxpoolgrad.h"
@@ -207,3 +208,4 @@ TEST(Fuse_MaxpoolGrad, with_overlay_multi_channel_multi_batch) {
     EXPECT_TRUE(output_tensor->CopyDataFromTensor(output_values.data()));
     EXPECT_EQ(golden, output_values);
 }
+#endif

--- a/src/tim/vx/ops/maxpoolwithargmax2.cc
+++ b/src/tim/vx/ops/maxpoolwithargmax2.cc
@@ -21,6 +21,7 @@
 *    DEALINGS IN THE SOFTWARE.
 *
 *****************************************************************************/
+#if VSI_FEAT_OP_MAXPOOLWITHARGMAX
 #include "tim/vx/ops/maxpoolwithargmax2.h"
 
 #include "direct_map_op_impl.h"
@@ -62,3 +63,5 @@ std::shared_ptr<Operation> MaxpoolWithArgmax2::Clone(
 }  // namespace ops
 }  // namespace vx
 }  // namespace tim
+
+#endif //(FEAT_OP_MAXPOOLWITHARGMAX)

--- a/src/tim/vx/ops/maxpoolwithargmax2_test.cc
+++ b/src/tim/vx/ops/maxpoolwithargmax2_test.cc
@@ -21,6 +21,7 @@
 *    DEALINGS IN THE SOFTWARE.
 *
 *****************************************************************************/
+#if VSI_FEAT_OP_MAXPOOLWITHARGMAX
 #include "tim/vx/context.h"
 #include "tim/vx/graph.h"
 #include "tim/vx/ops/maxpoolwithargmax2.h"
@@ -368,3 +369,5 @@ TEST(MaxpoolGrad, with_overlay_multi_channel_multi_batch) {
     EXPECT_TRUE(output_tensor->CopyDataFromTensor(output_values.data()));
     EXPECT_EQ(golden, output_values);
 }
+
+#endif //(VSI_FEAT_OP_MAXPOOLWITHARGMAX)


### PR DESCRIPTION
convert operation list(ops.def) as compiler flags in cmake, when add new
operation in tim-vx, always check if the feature define is avaiable or
not - so that tim-vx can compile with legacy ovxlib library.

Signed-off-by: xiang.zhang <xiang.zhang@verisilicon.com>