### PR TITLE
fixed some errs on gcc12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if(TIM_VX_ENABLE_TEST)
     FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG release-1.10.0
+    GIT_TAG release-1.12.0
     )
 
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)

--- a/include/tim/vx/ops/maxpoolgrad.h
+++ b/include/tim/vx/ops/maxpoolgrad.h
@@ -27,6 +27,7 @@
 #define TIM_VX_OPS_MAXPOOLGRAD_H_
 
 #include "tim/vx/operation.h"
+#include <array>
 namespace tim {
 namespace vx {
 namespace ops {

--- a/src/tim/vx/ops/stridedslice_test.cc
+++ b/src/tim/vx/ops/stridedslice_test.cc
@@ -26,6 +26,7 @@
 #include "tim/vx/ops/stridedslice.h"
 #include "tim/transform/layout_inference.h"
 
+#include <array>
 #include <algorithm>
 
 #include "gtest/gtest.h"


### PR DESCRIPTION
added C++ header <array> for some files when building TIM-VX on gcc12
upgrade fetched GoogleTest to release1.12.0