### PR TITLE
Fixed LayerNormalization eps bug

### DIFF
--- a/include/tim/vx/ops/layernormalization.h
+++ b/include/tim/vx/ops/layernormalization.h
@@ -38,7 +38,7 @@ class LayerNormalization : public Operation {
 
  protected:
   int32_t axis_;
-  int32_t eps_;
+  float eps_;
 };
 
 }  // namespace ops

--- a/src/tim/vx/ops/layernormalization.cc
+++ b/src/tim/vx/ops/layernormalization.cc
@@ -37,7 +37,7 @@ LayerNormalization::LayerNormalization(Graph* graph, int32_t axis, float eps)
     VSILOGE("Layer norm only support axis 0.");
     assert(false);
   }
-  this->impl()->node()->nn_param.instancenorm.eps = eps_;
+  this->impl()->node()->nn_param.layernorm.eps = eps_;
 }
 
 std::shared_ptr<Operation> LayerNormalization::Clone(


### PR DESCRIPTION
In the previous version, due to the wrong data type and parameters, the eps of layernorm cannot be set correctly, and it is always 0.
It will cause "nan" to appear in the output.

BUG results
test_LayerNorm_1_fp32
input: 
-2 2 -2 2 -2 2
-2 0 2 -2 0 2
2 2 2 2 2 2 
0 1 2 3 4 5
output:
-1 1 -1 1 -1 1 
-1.22474 0 1.22474 -1.22474 0 1.22474 
-nan -nan -nan -nan -nan -nan 
-1.46385 -0.87831 -0.29277 0.29277 0.87831 1.46385

