### PR TITLE
Enable float16 bias convolution model runs on NN

### DIFF
--- a/.github/workflows/cmake_x86_vsim.yml
+++ b/.github/workflows/cmake_x86_vsim.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
   workflow_dispatch:
     branches: [ main ]
-    
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release

--- a/include/tim/vx/graph.h
+++ b/include/tim/vx/graph.h
@@ -80,13 +80,14 @@ class Graph {
   virtual const std::vector<std::shared_ptr<Tensor>> InputsTensor() const = 0;
   virtual const std::vector<std::shared_ptr<Tensor>> OutputsTensor() const = 0;
 
-  virtual void UpdateTensorConsumersMap(
-      const std::shared_ptr<Tensor>& tensor,
-      const Operation* op) = 0;
+  virtual void UpdateTensorConsumersMap(const std::shared_ptr<Tensor>& tensor,
+                                        const Operation* op) = 0;
+  virtual void RenewTensorConsumersMap(
+      const std::shared_ptr<Tensor>& org_tensor,
+      const std::shared_ptr<Tensor>& dst_tensor, const Operation* op) = 0;
 
-  virtual void UpdateTensorProducerMap(
-      const std::shared_ptr<Tensor>& tensor,
-      const Operation* op) = 0;
+  virtual void UpdateTensorProducerMap(const std::shared_ptr<Tensor>& tensor,
+                                       const Operation* op) = 0;
 
   virtual const std::vector<std::shared_ptr<Operation>> GetConsumersOp(
       std::shared_ptr<Tensor> tensor) const = 0;

--- a/include/tim/vx/operation.h
+++ b/include/tim/vx/operation.h
@@ -49,16 +49,16 @@ class Operation {
   std::unique_ptr<OpImpl>& impl();
   const std::unique_ptr<OpImpl>& impl() const;
   virtual const std::vector<std::shared_ptr<Tensor>> ConstantInputsTensor() const;
-  
+
  protected:
   bool IsAllInputsConst() const;
   std::unique_ptr<OpImpl> impl_;
 
  private:
 // Post processing at the final step on BindInput func
-// - tensor : input tensor  
+// - tensor : input tensor
 // - input_idx: the index of input tensor
-   virtual void OnBindInputPostProc(const std::shared_ptr<Tensor>& tensor, int32_t input_idx); 
+   virtual void OnBindInputPostProc(const std::shared_ptr<Tensor>& tensor, int32_t input_idx);
 };
 
 }  // namespace vx

--- a/include/tim/vx/ops/conv2d.h
+++ b/include/tim/vx/ops/conv2d.h
@@ -37,7 +37,7 @@ namespace ops {
  *
  * Performs a 2-D convolution operation, include classic Conv2D /
  * Depthwise Conv2D / Group Conv2D / Dilation Conv2D.
- * 
+ *
  * Input:
  * - input [WHCN or CWHN].
  * - kernel [ WHIcOc ] (Ic: Input Channels. Oc: Output Channels).
@@ -95,6 +95,13 @@ class Conv2d : public BuiltinOp {
   const std::array<uint32_t, 4> pad_;
   const int32_t multiplier_;
   const DataLayout kernel_layout_;
+
+#if defined(__clang__) && (__clang_major__ >= 15)
+#define TIM_VX_OPS_CONV2D_WITH_F16BIAS 1
+ private:
+  void OnBindInputPostProc(const std::shared_ptr<Tensor>& tensor,
+                           int32_t input_idx) override;
+#endif
 };
 
 }  // namespace ops

--- a/src/tim/vx/graph.cc
+++ b/src/tim/vx/graph.cc
@@ -195,6 +195,22 @@ void GraphImpl::UpdateTensorConsumersMap(const std::shared_ptr<Tensor>& tensor,
   }
 }
 
+void GraphImpl::RenewTensorConsumersMap(
+    const std::shared_ptr<Tensor>& org_tensor,
+    const std::shared_ptr<Tensor>& dst_tensor, const Operation* op) {
+  auto exist_op = std::find_if(
+      op_vector_.begin(), op_vector_.end(),
+      [op](std::shared_ptr<Operation> oper) { return oper.get() == op; });
+  if (exist_op == op_vector_.end()) {
+    return;  //given op cannot be found
+  } else {
+    auto consumer_to_remove = tensor_consumers_.find(org_tensor);
+    if (consumer_to_remove != tensor_consumers_.end())
+      tensor_consumers_.erase(consumer_to_remove);
+    tensor_consumers_[dst_tensor].push_back(*exist_op);
+  }
+}
+
 void GraphImpl::UpdateTensorProducerMap(const std::shared_ptr<Tensor>& tensor,
                                          const Operation* op) {
   for (const auto& added_op : op_vector_) {

--- a/src/tim/vx/graph_private.h
+++ b/src/tim/vx/graph_private.h
@@ -62,6 +62,9 @@ class GraphImpl : public Graph {
 
   void UpdateTensorConsumersMap(const std::shared_ptr<Tensor>& tensor,
                                 const Operation* op) override;
+  void RenewTensorConsumersMap(const std::shared_ptr<Tensor>& org_tensor,
+                               const std::shared_ptr<Tensor>& dst_tensor,
+                               const Operation* op) override;
   void UpdateTensorProducerMap(const std::shared_ptr<Tensor>& tensor,
                                 const Operation* op) override;
   const std::vector<std::shared_ptr<Operation>> GetConsumersOp(


### PR DESCRIPTION
Convert float16 bias tensor to float32 to meet condition of NN convolution in driver

Caution: Clang version requires minimum 15.0

Type: Code Improvement
Issue: bugzilla id:32785 | jira id VIVD-744