### PR TITLE
Fixed transient deconv1d generate wrong output shape bug

### DIFF
--- a/src/tim/vx/internal/src/ops/vsi_nn_op_deconvolution1d.c
+++ b/src/tim/vx/internal/src/ops/vsi_nn_op_deconvolution1d.c
@@ -260,9 +260,8 @@ static vsi_bool op_setup
         }
         else
         {
-            outputs[0]->attr.size[1] = inputs[1]->attr.size[3];
+            outputs[0]->attr.size[1] = inputs[1]->attr.size[2];
         }
-        outputs[0]->attr.size[1] = nn_param->weights;
         outputs[0]->attr.size[2] = inputs[0]->attr.size[2];
         outputs[0]->attr.dim_num = inputs[0]->attr.dim_num;
     }


### PR DESCRIPTION
Fixed bug that when deconv1d ouput is set to be transient, actual output shape will be zero at dim 1.

Reason :internal typing error
Type: Bug Fix
Signed-off-by: Feiyue Chen <Feiyue.Chen@verisilicon.com>