### PR TITLE
Fixed IExecutable object not bind with DeviceID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,10 @@ if(${TIM_VX_CODE_COVERAGE})
     set(CMAKE_C_FLAGS "-g -O0 --coverage -fprofile-arcs -ftest-coverage")
 endif()
 
+if(${TIM_VX_ENABLE_PLATFORM})
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DENABLE_PLATFORM")
+endif()
+
 if(${TIM_VX_ENABLE_PLATFORM_LITE})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DENABLE_PLATFORM_LITE")
 endif()

--- a/include/tim/vx/compile_option.h
+++ b/include/tim/vx/compile_option.h
@@ -27,6 +27,10 @@
 #include <map>
 #include <memory>
 
+#if defined(ENABLE_PLATFORM)
+#include "platform/platform.h"
+#endif
+
 namespace tim {
 namespace vx {
 struct CompileOptionImpl;
@@ -37,6 +41,11 @@ class CompileOption {
 
   bool isRelaxMode() const;
   bool setRelaxMode(bool enable = false);
+
+#if defined(ENABLE_PLATFORM)
+  void setDeviceId(::tim::vx::platform::IDevice::device_id_t device);
+  ::tim::vx::platform::IDevice::device_id_t getDeviceId();
+#endif
 
   static CompileOption DefaultOptions;
 

--- a/include/tim/vx/graph.h
+++ b/include/tim/vx/graph.h
@@ -42,10 +42,14 @@ class Tensor;
 struct TensorSpec;
 struct DmaBufferDesc;
 class Operation;
+class CompileOption;
 
 class Graph {
  public:
   virtual ~Graph() {}
+
+  /// Attach CompileOption
+  virtual void SetCompileOption(const CompileOption&) = 0;
 
   /// Create a tensor with given `TensorSpec`
   virtual std::shared_ptr<Tensor> CreateTensor(const TensorSpec& spec,

--- a/include/tim/vx/platform/platform.h
+++ b/include/tim/vx/platform/platform.h
@@ -31,7 +31,6 @@
 #include "tim/vx/graph.h"
 #include "tim/vx/tensor.h"
 #include "tim/vx/context.h"
-#include "tim/vx/ops/nbg.h"
 
 namespace tim {
 namespace vx {

--- a/src/tim/vx/compile_option.cc
+++ b/src/tim/vx/compile_option.cc
@@ -34,6 +34,9 @@ struct CompileOptionImpl {
   using RelaxModeType = std::tuple<std::string, bool, bool, bool>;
   CompileOptionImpl() {
     relax_mode_ = RelaxModeType(std::string("RelaxMode"), false, false, false);
+    #if defined(ENABLE_PLATFORM)
+    device_id_ = 0;
+    #endif
   }
 
   bool RelaxMode() const {
@@ -46,6 +49,17 @@ struct CompileOptionImpl {
                                     : std::get<3>(relax_mode_);
   }
 
+#if defined(ENABLE_PLATFORM)
+  void setDeviceId(::tim::vx::platform::IDevice::device_id_t device) {
+    device_id_ = device;
+  }
+  ::tim::vx::platform::IDevice::device_id_t getDeviceId() {
+    return device_id_;
+  }
+
+  ::tim::vx::platform::IDevice::device_id_t device_id_;
+#endif
+
   RelaxModeType relax_mode_;
 };
 
@@ -56,5 +70,17 @@ bool CompileOption::isRelaxMode() const { return this->impl_->RelaxMode(); }
 bool CompileOption::setRelaxMode(bool enable) {
   return this->impl_->RelaxMode() = enable;
 }
+
+#if defined(ENABLE_PLATFORM)
+  void CompileOption::setDeviceId(::tim::vx::platform::IDevice::device_id_t device) {
+    this->impl_->setDeviceId(device);
+  }
+
+  ::tim::vx::platform::IDevice::device_id_t CompileOption::getDeviceId() {
+    return this->impl_->getDeviceId();
+  }
+
+
+#endif
 }  // namespace vx
 }  // namespace tim

--- a/src/tim/vx/graph.cc
+++ b/src/tim/vx/graph.cc
@@ -150,6 +150,10 @@ std::shared_ptr<Tensor> GraphImpl::GetTensorFromCache(const TensorSpec& spec, co
 }
 #endif
 
+void GraphImpl::SetCompileOption(const CompileOption& new_options) {
+  options_ = new_options;
+}
+
 vsi_nn_graph_t* GraphImpl::graph() { return graph_; }
 
 void GraphImpl::AddInput(vsi_nn_tensor_id_t id) {
@@ -320,6 +324,12 @@ bool GraphImpl::Setup() {
             "mode which will have better performance but lower precesion");
   }
   vsi_nn_SetGraphFastMode(graph_, is_fast_mode);
+
+  #if defined(ENABLE_PLATFORM)
+  auto id = options_.getDeviceId();
+  vxSetGraphAttribute(graph_->g, VX_GRAPH_DEVICE_INDEX_VIV,
+                      (void*)(&id), sizeof(id));
+  #endif
 
   std::call_once(setio_once_, [&status, this]() {
     status = (vsi_nn_SetGraphInputs(this->graph_, this->inputs_.data(),

--- a/src/tim/vx/graph_private.h
+++ b/src/tim/vx/graph_private.h
@@ -49,6 +49,9 @@ class GraphImpl : public Graph {
   const std::string CalculateCacheKey(const TensorSpec& spec, const void* data);
   std::map<std::string, std::shared_ptr<tim::vx::Tensor>>& GetTensorCacheMap();
 #endif
+
+  void SetCompileOption(const CompileOption& new_option) override;
+
   /// Return the low-level graph object
   vsi_nn_graph_t* graph();
   void AddInput(vsi_nn_tensor_id_t id);


### PR DESCRIPTION
If Executable object doesn't bind with a concrete DeviceID, it will go first device by default.

When run multi executable with multi device, the behavior is not expected. Fixed by attach device id with CompileOption.