### PR TITLE
Refine UnitTest which have acc issue or unspport issue in sp

### DIFF
--- a/include/tim/vx/context.h
+++ b/include/tim/vx/context.h
@@ -38,6 +38,7 @@ class Context {
   virtual std::shared_ptr<Graph> CreateGraph(const CompileOption& options) = 0;
 
   virtual bool isClOnly() = 0;
+  virtual bool hasSP() = 0;
 
   static std::shared_ptr<Context> Create();
 };

--- a/src/tim/vx/context.cc
+++ b/src/tim/vx/context.cc
@@ -58,5 +58,9 @@ bool ContextImpl::isClOnly() {
     return VSI_NN_HW_EVIS_NONE == context_->config.evis.ver;
 }
 
+bool ContextImpl::hasSP() {
+    return 0 != context_->config.support_stream_processor;
+}
+
 }  // namespace vx
 }  // namespace tim

--- a/src/tim/vx/context_private.h
+++ b/src/tim/vx/context_private.h
@@ -37,7 +37,8 @@ class ContextImpl : public Context {
   std::shared_ptr<Graph> CreateGraph() override;
   std::shared_ptr<Graph> CreateGraph(const CompileOption&) override;
   bool isClOnly() override;
-  
+  bool hasSP() override;
+
  protected:
   vsi_nn_context_t context_;
 };

--- a/src/tim/vx/ops/elementwise_test.cc
+++ b/src/tim/vx/ops/elementwise_test.cc
@@ -31,6 +31,7 @@
 TEST(FloorDiv, shape_1_fp32) {
     auto ctx = tim::vx::Context::Create();
     auto graph = ctx->CreateGraph();
+    if (ctx->hasSP()) GTEST_SKIP();
 
     tim::vx::ShapeType io_shape({1});
     tim::vx::TensorSpec input_spec(tim::vx::DataType::FLOAT32,
@@ -135,6 +136,7 @@ TEST(FloorDiv, shape_5_1_broadcast_uint8) {
 TEST(Div, shape_1_fp32) {
     auto ctx = tim::vx::Context::Create();
     auto graph = ctx->CreateGraph();
+    if (ctx->hasSP()) GTEST_SKIP();
 
     tim::vx::ShapeType io_shape({1});
     tim::vx::TensorSpec input_spec(tim::vx::DataType::FLOAT32,

--- a/src/tim/vx/ops/grucell_test.cc
+++ b/src/tim/vx/ops/grucell_test.cc
@@ -35,6 +35,7 @@ std::shared_ptr<tim::vx::Tensor> make_empty_tensor(
 TEST(GRUCell, unit_4) {
   auto ctx = tim::vx::Context::Create();
   auto graph = ctx->CreateGraph();
+  float tolerance = ctx->hasSP() ? 1e-4f : 1e-5f;
 
   uint32_t num_units = 2;
   uint32_t feature = 4;
@@ -118,5 +119,5 @@ TEST(GRUCell, unit_4) {
 
   std::vector<float> output(golden.size());
   EXPECT_TRUE(output_tensor->CopyDataFromTensor(output.data()));
-  EXPECT_TRUE(ArraysMatch(golden, output, 1e-5f));
+  EXPECT_TRUE(ArraysMatch(golden, output, tolerance));
 }

--- a/src/tim/vx/ops/layernormalization_test.cc
+++ b/src/tim/vx/ops/layernormalization_test.cc
@@ -30,6 +30,7 @@
 TEST(LayerNorm, axis_0_shape_3_6_1_float) {
     auto ctx = tim::vx::Context::Create();
     auto graph = ctx->CreateGraph();
+    float tolerance = ctx->hasSP() ? 0.01 : 1e-5f;
 
     tim::vx::ShapeType io_shape({3, 6, 1});
     tim::vx::ShapeType param_shape({6});
@@ -81,12 +82,13 @@ TEST(LayerNorm, axis_0_shape_3_6_1_float) {
 
     std::vector<float> output(18);
     EXPECT_TRUE(output_tensor->CopyDataFromTensor(output.data()));
-    EXPECT_TRUE(ArraysMatch(golden, output, 1e-5f));
+    EXPECT_TRUE(ArraysMatch(golden, output, tolerance));
 }
 
 TEST(LayerNorm, axis_0_shape_2_3_6_1_float) {
     auto ctx = tim::vx::Context::Create();
     auto graph = ctx->CreateGraph();
+    float tolerance = ctx->hasSP() ? 0.01 : 1e-5f;
 
     tim::vx::ShapeType io_shape({2, 3, 6, 1});
     tim::vx::ShapeType param_shape({6});
@@ -139,12 +141,13 @@ TEST(LayerNorm, axis_0_shape_2_3_6_1_float) {
 
     std::vector<float> output(36);
     EXPECT_TRUE(output_tensor->CopyDataFromTensor(output.data()));
-    EXPECT_TRUE(ArraysMatch(golden, output, 1e-5f));
+    EXPECT_TRUE(ArraysMatch(golden, output, tolerance));
 }
 
 TEST(LayerNorm, axis_2_shape_4_2_3_1_float) {
     auto ctx = tim::vx::Context::Create();
     auto graph = ctx->CreateGraph();
+    float tolerance = ctx->hasSP() ? 0.01 : 1e-5f;
 
     tim::vx::ShapeType io_shape({4, 2, 3, 1});
     tim::vx::ShapeType param_shape({1,1,3,1});
@@ -194,7 +197,7 @@ TEST(LayerNorm, axis_2_shape_4_2_3_1_float) {
 
     std::vector<float> output(24);
     EXPECT_TRUE(output_tensor->CopyDataFromTensor(output.data()));
-    EXPECT_TRUE(ArraysMatch(golden, output, 1e-5f));
+    EXPECT_TRUE(ArraysMatch(golden, output, tolerance));
 }
 
 #if 0

--- a/src/tim/vx/ops/relational_operations_test.cc
+++ b/src/tim/vx/ops/relational_operations_test.cc
@@ -65,6 +65,7 @@ TEST(Equal, shape_1_uint8) {
 
 TEST(NotEqual, shape_5_fp32) {
     auto ctx = tim::vx::Context::Create();
+    if (ctx->hasSP()) GTEST_SKIP();
     auto graph = ctx->CreateGraph();
 
     tim::vx::ShapeType io_shape({5});
@@ -101,6 +102,7 @@ TEST(NotEqual, shape_5_fp32) {
 TEST(Less, shape_5_1_fp32) {
     auto ctx = tim::vx::Context::Create();
     auto graph = ctx->CreateGraph();
+    if (ctx->hasSP()) GTEST_SKIP();
 
     tim::vx::ShapeType io_shape({1,5});
     tim::vx::TensorSpec input_spec(tim::vx::DataType::FLOAT32,
@@ -136,6 +138,7 @@ TEST(Less, shape_5_1_fp32) {
 TEST(GreaterOrEqual, shape_5_2_1_fp32) {
     auto ctx = tim::vx::Context::Create();
     auto graph = ctx->CreateGraph();
+    if (ctx->hasSP()) GTEST_SKIP();
 
     tim::vx::ShapeType io_shape({5,2,1});
     tim::vx::TensorSpec input_spec(tim::vx::DataType::FLOAT32,
@@ -175,6 +178,7 @@ TEST(GreaterOrEqual, shape_5_2_1_fp32) {
 TEST(Greater, shape_5_2_1_1_fp32) {
     auto ctx = tim::vx::Context::Create();
     auto graph = ctx->CreateGraph();
+    if (ctx->hasSP()) GTEST_SKIP();
 
     tim::vx::ShapeType io_shape({5,2,1,1});
     tim::vx::TensorSpec input_spec(tim::vx::DataType::FLOAT32,
@@ -214,6 +218,7 @@ TEST(Greater, shape_5_2_1_1_fp32) {
 TEST(LessOrEqual, shape_1_5_2_1_1_fp32) {
     auto ctx = tim::vx::Context::Create();
     auto graph = ctx->CreateGraph();
+    if (ctx->hasSP()) GTEST_SKIP();
 
     tim::vx::ShapeType io_shape({1,5,2,1,1});
     tim::vx::TensorSpec input_spec(tim::vx::DataType::FLOAT32,

--- a/src/tim/vx/ops/softmax_test.cc
+++ b/src/tim/vx/ops/softmax_test.cc
@@ -57,7 +57,10 @@ TEST(Softmax, shape_3_1_float_axis_0) {
 
     std::vector<float> output(golden.size());
     EXPECT_TRUE(output_tensor->CopyDataFromTensor(output.data()));
-    EXPECT_TRUE(ArraysMatch(golden, output, 1e-5f));
+    if (!ctx->hasSP())
+      EXPECT_EQ(golden, output);
+    else
+      EXPECT_TRUE(ArraysMatch(golden, output, 1e-3f));
 }
 
 TEST(Softmax, shape_3_4_float_axis_0) {
@@ -96,8 +99,10 @@ TEST(Softmax, shape_3_4_float_axis_0) {
 
     std::vector<float> output(golden.size());
     EXPECT_TRUE(output_tensor->CopyDataFromTensor(output.data()));
-    EXPECT_EQ(golden, output);
-    // EXPECT_TRUE(ArraysMatch(golden, output, 1e-5f));
+    if (!ctx->hasSP())
+      EXPECT_EQ(golden, output);
+    else
+      EXPECT_TRUE(ArraysMatch(golden, output, 1e-3f));
 }
 
 TEST(Softmax, shape_3_4_float_axis_1) {
@@ -136,8 +141,10 @@ TEST(Softmax, shape_3_4_float_axis_1) {
 
     std::vector<float> output(golden.size());
     EXPECT_TRUE(output_tensor->CopyDataFromTensor(output.data()));
-    EXPECT_EQ(golden, output);
-    // EXPECT_TRUE(ArraysMatch(golden, output, 1e-5f));
+    if (!ctx->hasSP())
+      EXPECT_EQ(golden, output);
+    else
+      EXPECT_TRUE(ArraysMatch(golden, output, 1e-3f));
 }
 
 TEST(Softmax, shape_3_3_2_float_axis_0) {
@@ -182,8 +189,10 @@ TEST(Softmax, shape_3_3_2_float_axis_0) {
 
     std::vector<float> output(golden.size());
     EXPECT_TRUE(output_tensor->CopyDataFromTensor(output.data()));
-    EXPECT_EQ(golden, output);
-    // EXPECT_TRUE(ArraysMatch(golden, output, 1e-5f));
+    if (!ctx->hasSP())
+      EXPECT_EQ(golden, output);
+    else
+      EXPECT_TRUE(ArraysMatch(golden, output, 1e-3f));
 }
 
 TEST(Softmax, shape_3_3_2_float_axis_1) {
@@ -228,8 +237,10 @@ TEST(Softmax, shape_3_3_2_float_axis_1) {
 
     std::vector<float> output(golden.size());
     EXPECT_TRUE(output_tensor->CopyDataFromTensor(output.data()));
-    EXPECT_EQ(golden, output);
-    // EXPECT_TRUE(ArraysMatch(golden, output, 1e-5f));
+    if (!ctx->hasSP())
+      EXPECT_EQ(golden, output);
+    else
+      EXPECT_TRUE(ArraysMatch(golden, output, 1e-3f));
 }
 
 TEST(Softmax, shape_3_3_2_float_axis_2) {
@@ -274,6 +285,8 @@ TEST(Softmax, shape_3_3_2_float_axis_2) {
 
     std::vector<float> output(golden.size());
     EXPECT_TRUE(output_tensor->CopyDataFromTensor(output.data()));
-    EXPECT_EQ(golden, output);
-    // EXPECT_TRUE(ArraysMatch(golden, output, 1e-5f));
+    if (!ctx->hasSP())
+      EXPECT_EQ(golden, output);
+    else
+      EXPECT_TRUE(ArraysMatch(golden, output, 1e-3f));
 }

--- a/src/tim/vx/ops/unidirectional_sequence_gru_test.cc
+++ b/src/tim/vx/ops/unidirectional_sequence_gru_test.cc
@@ -35,6 +35,7 @@ std::shared_ptr<tim::vx::Tensor> make_empty_tensor(
 TEST(UnidirectionalSequenceGRU, unit_3) {
   auto ctx = tim::vx::Context::Create();
   auto graph = ctx->CreateGraph();
+  float tolerance = ctx->hasSP() ? 1e-4f : 1e-5f;
 
   const int timesteps = 1;
   const int batchs = 1;
@@ -125,5 +126,5 @@ TEST(UnidirectionalSequenceGRU, unit_3) {
 
   std::vector<float> output(golden.size());
   EXPECT_TRUE(output_tensor->CopyDataFromTensor(output.data()));
-    EXPECT_TRUE(ArraysMatch(golden, output, 1e-5f));
+    EXPECT_TRUE(ArraysMatch(golden, output, tolerance));
 }


### PR DESCRIPTION
1.Skip elementwise/relational op unittest if input/output have INF which sp cannot handle
2.Set different tolerance in Layernom/SoftMax/GRU unittest if SP supported

Type: Bug Fix
Issue: 37103