### PR TITLE
Fixed layout infer bug when some op is not in op_vector_

### DIFF
--- a/src/tim/transform/mean_stddev_normalize_fusion.cc
+++ b/src/tim/transform/mean_stddev_normalize_fusion.cc
@@ -109,12 +109,14 @@ void RemoveTensorsAndOps(
     std::shared_ptr<vx::Graph>& graph,
     const std::vector<std::shared_ptr<vx::Operation>>& norm_ops) {
   for (uint32_t i = 0; i < norm_ops.size(); i++) {
-    auto it =
+   auto it =
         std::remove_if(graph->OpVector().begin(), graph->OpVector().end(),
                        [norm_ops, i](std::shared_ptr<vx::Operation> oper) {
                          return oper == norm_ops[i];
                        });
-    graph->OpVector().erase(it);  //Remove current op from op_vector_
+    if (it != graph->OpVector().end()) {
+      graph->OpVector().erase(it);
+    }  // Remove current op from op_vector_
     auto input_tensors = norm_ops[i]->impl()->InputsTensor();
     auto output_tensors = norm_ops[i]->impl()->OutputsTensor();
 


### PR DESCRIPTION
Backgroud: instance_norm models run crash after latest lay out code refine

Reason: The refactored code treats the ops that not in the initial op vector as out of bounds access

Solution: Refactored normalize_fusion code to ensure no op is deleted wrongly in op_vector_

Type:  Bug Fix
Issue: 37449