### PR TITLE
Disable two warnings as errors for ovxlib bazel

### DIFF
--- a/src/tim/vx/internal/BUILD
+++ b/src/tim/vx/internal/BUILD
@@ -75,7 +75,10 @@ filegroup(
 cc_library(
     name = "ovxlibimpl",
     copts = [
-        "-Werror", "-Wmisleading-indentation",
+        "-Werror",
+        "-Wno-strict-aliasing",
+        "-Wno-unused-but-set-variable",
+        "-Wmisleading-indentation",
         "-fvisibility=hidden", '-DOVXLIB_API=__attribute__((visibility(\\"default\\")))',
     ],
     linkopts = ["-ldl", "-lm"],


### PR DESCRIPTION
Workaround for VSI NPU PJRT plugin bazel build, the `strict-aliasing` and `unused-but-set-variable` warnings are not treated as errors for now. In the future, the ovxlib team should fix those warnings.