### PR TITLE
add a timeout for TIM-VX check

### DIFF
--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -37,8 +37,21 @@ jobs:
     steps:
       - name: check_TIM-VX_result
         run: |
+          start_time=$(date +%s)
+          max_duration=3600
+          
           while true
           do
+              current_time=$(date +%s)
+
+              elapsed_time=$((current_time - start_time))
+
+              if [[ $elapsed_time -ge $max_duration ]];then
+                  echo "TIM-VX result check has exceeded 1 hour."
+                  echo "Please check the local board."
+                  exit 1
+              fi
+
               if [[ -e /home/vip_sqa/build_case/result/TIM-VX_unit_test_qua.txt ]];then
                   total_num=`cat /home/vip_sqa/build_case/result/TIM-VX_unit_test_qua.txt | grep "Total" | awk -F ':' '{print $2}' | sed 's/ //g'`
                   pass_num=`cat /home/vip_sqa/build_case/result/TIM-VX_unit_test_qua.txt | grep "Pass" | awk -F ':' '{print $2}' | sed 's/ //g'`


### PR DESCRIPTION
add a TIMEOUT for TIM-VX check. If this step fails, there is a high probability that the local board has problems.There is a TIMEOUT to find problems faster.