### PR TITLE
Fix the __system_property_get undeclared function error

### DIFF
--- a/src/tim/vx/internal/src/utils/vsi_nn_util.c
+++ b/src/tim/vx/internal/src/utils/vsi_nn_util.c
@@ -35,6 +35,9 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#if defined(__ANDROID__)
+    #include <sys/system_properties.h>
+#endif
 #endif
 
 #include "vsi_nn_prv.h"


### PR DESCRIPTION
For Android 14 (API level 34) NDK 26

Type: Bug fix