### PR TITLE
Add include of cstdint to permute_vector.h

### DIFF
--- a/src/tim/transform/permute_vector.h
+++ b/src/tim/transform/permute_vector.h
@@ -26,6 +26,7 @@
 
 #include <array>
 #include <cassert>
+#include <cstdint>
 #include <memory>
 #include <vector>
 #include <string>


### PR DESCRIPTION
This avoids the following error with GCC 15:

```
  src/tim/transform/ops/../permute_vector.h:41:11: error: 'uint32_t'
  does not name a type
     41 |   virtual uint32_t Rank() const = 0;
        |           ^~~~~~~~
  src/tim/transform/ops/../permute_vector.h:32:1: note: 'uint32_t' is
  defined in header '<cstdint>'; this is probably fixable by adding
  '#include <cstdint>'
     31 | #include <string>
    +++ |+#include <cstdint>
     32 |
```