### PR TITLE
Fix layout inference issue

### DIFF
--- a/src/tim/transform/layout_inference.cc
+++ b/src/tim/transform/layout_inference.cc
@@ -385,7 +385,6 @@ LayoutInference(
     auto output = infer_graph->CreateTensor(t_src->GetSpec());
     layout_infer_ctx->UpdateTensorMap(t_src, output);
     layout_infer_ctx->UpdateGraphOutputMap(t_src, output);
-    tensor_queue.push(t_src);
     layout_infer_ctx->SetPermuteVector(
         t_src, tensor_pv_map.find(t_src) != tensor_pv_map.end()
                    ? tensor_pv_map[t_src]


### PR DESCRIPTION
The outputs of a graph should not be directly placed into the tensor queue of the layout inference firstly. 
If a graph output also serves as an input to other nodes within the same graph (meaning it has consumer nodes), 
placing it prematurely could disrupt the correct execution sequence when the graph is being processed.

Type: Bug fix