### PR TITLE
Fix VX device API compatibility issue

### DIFF
--- a/src/tim/vx/graph.cc
+++ b/src/tim/vx/graph.cc
@@ -342,7 +342,7 @@ bool GraphImpl::Setup() {
   }
   vsi_nn_SetGraphFastMode(graph_, is_fast_mode);
 
-#if defined(ENABLE_PLATFORM)
+#if defined(ENABLE_PLATFORM) && !defined(VSI_DEVICE_SUPPORT)
   auto id = options_.getDeviceId();
   vxSetGraphAttribute(graph_->g, VX_GRAPH_DEVICE_INDEX_VIV, (void*)(&id),
                       sizeof(id));


### PR DESCRIPTION
If VSI_DEVICE_SUPPORT is defined, vxSetGraphAttribute is no longer needed to specify the device.