### PR TITLE
Disable platform for CI

### DIFF
--- a/.github/workflows/cmake_x86_vsim.yml
+++ b/.github/workflows/cmake_x86_vsim.yml
@@ -26,7 +26,7 @@ jobs:
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: |
-        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DTIM_VX_ENABLE_TEST=ON -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/tim-vx.install.dir/ -DTIM_VX_BUILD_EXAMPLES=ON -DTIM_VX_ENABLE_PLATFORM=ON -DTIM_VX_ENABLE_CUSTOM_OP=ON
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DTIM_VX_ENABLE_TEST=ON -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/tim-vx.install.dir/ -DTIM_VX_BUILD_EXAMPLES=ON -DTIM_VX_ENABLE_PLATFORM=OFF -DTIM_VX_ENABLE_CUSTOM_OP=ON
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/cmake_x86_vsim.yml
+++ b/.github/workflows/cmake_x86_vsim.yml
@@ -88,9 +88,9 @@ jobs:
       run: |
         cd ${{github.workspace}}/tim-vx.install.dir/bin
         chmod u+x multi_thread_test
-        chmod u+x lenet_multi_device
+        #chmod u+x lenet_multi_device
         ./multi_thread_test
-        ./lenet_multi_device
+        #./lenet_multi_device
 
   # cl-only test
   tim-vx-unit-test-cl:


### PR DESCRIPTION
Since the internal OVXLIB version is lower than 1.2.26, temporarily disable the platform option.